### PR TITLE
Add srcloc to snippet parse error message

### DIFF
--- a/src/Diagrams/Builder/Modules.hs
+++ b/src/Diagrams/Builder/Modules.hs
@@ -55,7 +55,7 @@ emptyModule = Module noLoc (ModuleName "Main") [] Nothing Nothing [] []
 doModuleParse :: String -> Either String Module
 doModuleParse src =
   case parseFileContentsWithMode parseMode src of
-    ParseFailed _ err -> Left err
+    ParseFailed sloc err -> Left (prettyPrint sloc ++ ": " ++ err)
     ParseOk m         -> return m
   where
     parseMode


### PR DESCRIPTION
Snippet modules that has parse errors now shows line and column numbers.

Not sure if this is meant to be used this way, but I had a tool on-demand compiles a module (passed in as a snippet) that generates a diagram, and I found the parse errors in this module did not show line numbers.

Tested by patching the hackage version with this diff, and verified that parse errors did show source loc.
