### PR TITLE
Support a DIAGRAMS_SANDBOX environment variable.

### DIFF
--- a/diagrams-builder.cabal
+++ b/diagrams-builder.cabal
@@ -167,4 +167,4 @@ executable diagrams-builder-rasterific
                        diagrams-rasterific >= 0.1 && < 0.2,
                        cmdargs >= 0.6 && < 0.11,
                        lens >= 3.8 && < 4.7,
-                       JuicyPixels >= 3.2 && < 3.3
+                       JuicyPixels >= 3.1 && < 3.3

--- a/src/tools/diagrams-builder-rasterific.hs
+++ b/src/tools/diagrams-builder-rasterific.hs
@@ -52,7 +52,7 @@ build :: Build
 build =
   defaultBuildOpts
   { outFile  = "out.png" &= typFile &= help "Output file (default: \"out.png\")" }
-  &= summary "The diagrams-builder-rasterific program, for dynamically rendering diagrams using the rasterific backend.  Give it a source file and an expression to render (which may refer to things declared in the source file), and it outputs an image, using hashing to avoid rerendering images unnecessarily."
+  &= summary "The diagrams-builder-rasterific program, for dynamically rendering diagrams using the rasterific backend.  Give it a source file and an expression to render (which may refer to things declared in the source file), and it outputs an image, using hashing to avoid rerendering images unnecessarily.\n\nIf you have installed the diagrams-lib and diagrams-rasterific packages in a sandbox, set the environment variable DIAGRAMS_SANDBOX to that directory so the builder can compile your diagram. For example, \"export DIAGRAMS_SANDBOX=~/diagrams/.cabal-sandbox\". If you have package databases for multiple versions of GHC in that sandbox, you will need to set the full path to the package database (it ends in \".conf.d\")."
   &= program "diagrams-builder-rasterific"
 
 main :: IO ()


### PR DESCRIPTION
This can be set to any sandbox directory where diagrams-lib and
diagrams-rasterific (for example) are installed.
