### PR TITLE
diagrams-latex: Fix directory creation on Windows

### DIFF
--- a/latex/diagrams-latex.sty
+++ b/latex/diagrams-latex.sty
@@ -208,7 +208,11 @@
     \ifdtt@ForceShellEscape
         \dtt@ShellEscapetrue
     \fi
-    \immediate\write18{mkdir -p \dtt@outputdir}
+    \ifwindows
+      \immediate\write18{if not exist \dtt@outputdir\space mkdir \dtt@outputdir}
+    \else
+      \immediate\write18{mkdir -p \dtt@outputdir}
+    \fi
     \xdef\diagramslatexCutFile{\dtt@figname.hs}
     \diagramslatexverbatimwrite{\diagramslatexCutFile}}
     {\enddiagramslatexverbatimwrite%


### PR DESCRIPTION
mkdir on Windows has no -p option, so without this fix a directory named "-p" is created. With this fix the behaviour should be the same; parent directories are also created by the Windows mkdir. 