### PR TITLE
diagrams-builder.cabal: allow haskell-src-exts-1.17

### DIFF
--- a/diagrams-builder.cabal
+++ b/diagrams-builder.cabal
@@ -57,7 +57,7 @@ library
                        filepath,
                        transformers >= 0.3 && < 0.5,
                        split >= 0.2 && < 0.3,
-                       haskell-src-exts >= 1.16 && < 1.17,
+                       haskell-src-exts >= 1.16 && < 1.18,
                        cmdargs >= 0.6 && < 0.11,
                        lens >= 4.0 && < 4.14,
                        hashable >= 1.1 && < 1.3,


### PR DESCRIPTION
Signed-off-by: Sergei Trofimovich <siarheit@google.com>