### PR TITLE
Use Stack on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,43 @@
-language: haskell
-
-env:
-  matrix:
-    - HPVER=2014.2.0.0
-    - GHCVER=7.8.4
-    - GHCVER=7.10.2
-  global:
-    - CABALVER=1.22
-    - UBUNTU_PKGS="libgtk-3-dev libcairo2-dev"
-    - EXTRA_DEPS_PRE="gtk2hs-buildtools"
-    - HEAD_DEPS="diagrams-core diagrams-lib diagrams-cairo diagrams-svg diagrams-postscript diagrams-rasterific active dual-tree monoid-extras statestack diagrams-solve"
-    - CABAL_FLAGS="-fcairo -fsvg -fps -frasterific"
-
-matrix:
-  allow_failures:
-    - env: GHCVER=7.10.2
+sudo: false
 
 before_install:
-  - git clone http://github.com/diagrams/diagrams-travis travis
-  - source travis/scripts/set_env.sh
-  - ./travis/scripts/before_install.sh
+  # stack
+  - mkdir -p ~/.local/bin
+  - export PATH=/opt/ghc/7.10.2/bin:$PATH
+  - export PATH=~/.local/bin:$PATH
+  - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+  - git clone -b stack http://github.com/diagrams/diagrams-travis travis
+  - stack install gtk2hs-buildtools
+  - ./travis/scripts/git_deps.sh
 
-install: ./travis/scripts/install.sh
+addons:
+  apt:
+    sources:
+    - hvr-ghc
+    packages:
+    - ghc-7.10.2
+    - libgmp-dev
+    - libgtk-3-dev
+    - libcairo2-dev
+    - libpango1.0-dev
 
-script: ./travis/scripts/script.sh
+env:
+  global:
+    - HEAD_DEPS="diagrams-core diagrams-lib diagrams-cairo diagrams-svg diagrams-postscript diagrams-rasterific active dual-tree monoid-extras statestack diagrams-solve"
+    - STACK_YAML='travis-stack.yaml'
 
+install:
+  - ./travis_long stack --no-terminal --skip-ghc-check setup
+  - ./travis_long stack --no-terminal --skip-ghc-check test --only-snapshot
+
+script:
+  - stack --no-terminal --skip-ghc-check test
+
+# Caching so the next build will be fast too.
+cache:
+  directories:
+  - $HOME/.stack
+  
 notifications:
   email: false
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ addons:
 
 env:
   global:
-    - HEAD_DEPS="diagrams-core diagrams-lib diagrams-cairo diagrams-svg diagrams-postscript diagrams-rasterific active dual-tree monoid-extras statestack diagrams-solve"
+    - HEAD_DEPS="diagrams-core diagrams-lib diagrams-cairo diagrams-svg diagrams-postscript diagrams-rasterific diagrams-pgf active dual-tree monoid-extras statestack diagrams-solve"
     - STACK_YAML='travis-stack.yaml'
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ before_install:
   - export PATH=~/.local/bin:$PATH
   - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
   - git clone -b stack http://github.com/diagrams/diagrams-travis travis
-  - stack install gtk2hs-buildtools
   - ./travis/scripts/git_deps.sh
+  - stack install gtk2hs-buildtools
 
 addons:
   apt:

--- a/travis-stack.yaml
+++ b/travis-stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-3.11
+resolver: lts-3.16
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/travis-stack.yaml
+++ b/travis-stack.yaml
@@ -1,0 +1,54 @@
+# For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-3.11
+
+# Local packages, usually specified by relative directory name
+packages:
+  - '.'
+  - monoid-extras
+  - dual-tree
+  - diagrams-core
+  - diagrams-solve
+  - active
+  - diagrams-lib
+  - diagrams-cairo
+  - diagrams-pgf
+  - diagrams-postscript
+  - diagrams-rasterific
+  - diagrams-svg
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps:
+  - linear-1.20.2 # types of inverse functions changed in 1.20
+  - vector-0.11.0.0 # required for latest linear
+  - texrunner-0.0.1.0
+  - lucid-svg-0.6.0.0
+
+# Override default flag values for local packages and extra-deps
+flags:
+  diagrams-builder:
+    cairo: true
+    pgf: true
+    postscript: true
+    ps: true
+    rasterific: true
+    svg: true
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 0.1.4.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]

--- a/travis_long
+++ b/travis_long
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+$* &
+pidA=$!
+minutes=0
+
+while true; do sleep 60; ((minutes++)); echo -e "\033[0;32m$minutes minute(s) elapsed.\033[0m"; done &
+    pidB=$!
+
+    wait $pidA
+    exitCode=$?
+
+    echo -e "\033[0;32m$* finished.\033[0m"
+
+    kill -9 $pidB
+    exit $exitCode


### PR DESCRIPTION
The travis CI build for `diagrams-builder` is frequently broken - I think much more often than our other packages.  This is often due to cabal solver failures.  Debugging these is a pain, and I don't think it's a good use of time.  I'd like to switch the travis build to use Stack, so it's always using reasonable package versions, and we can get more feedback about more interesting breakage.

Right now this checks out the `stack` branch of `diagrams-travis`, but we should probably merge that branch into master.