### PR TITLE
Remove Diagrams.Core.Types import

### DIFF
--- a/src/Diagrams/Builder.hs
+++ b/src/Diagrams/Builder.hs
@@ -103,7 +103,6 @@ setDiagramImports m imps = do
       map (, Nothing)
         [ "Prelude"
         , "Diagrams.Prelude"
-        , "Diagrams.Core.Types"
         , "Data.Monoid"
         ]
         ++ imps


### PR DESCRIPTION
Not sure yet that this is a good idea, but opening the PR to discuss.

I was having some import conflicts for `QDiagram` when I was working on diagrams-doc. (The error said that `QDiagram` was imported twice---once from Diagrams.Prelude and once from Diagrams.Core.Types.) So one obvious way to fix it is what I did here---remove the Diagrams.Core.Types import.

I'm curious about a few things:

* Has anyone run into this error before? 
* What is the purpose of importing Diagrams.Core.Types here? Was there some other type that you wanted to import? Maybe we should take a look at the types we need (the ones not included in Diagrams.Prelude) and only import those.