### PR TITLE
Improvements to diagrams-latex.sty

### DIFF
--- a/latex/diagrams-latex.sty
+++ b/latex/diagrams-latex.sty
@@ -9,7 +9,7 @@
 
 %% diagrams-latex.sty
 %% Copyright (c) 2011-2012, Ryan Yates
-%% 
+%%
 %% Large portions copied from dot2texi.sty
 %%
 %% Copyright (c) 2007-2008, Kjell Magne Fauske
@@ -60,6 +60,8 @@
 \RequirePackage{xkeyval}[2005/02/22]
 \RequirePackage{ifthen}
 
+\RequirePackage{graphics}
+
 \newif\ifdtt@ShellEscape
 %\newif\ifmiktex \miktexfalse
 \newif\ifdtt@ForceShellEscape \dtt@ForceShellEscapefalse
@@ -72,9 +74,9 @@
 \DeclareOptionX{miktex}{} % dummy (for backwards compatability)
 
 % Options for setting output size
-\DeclareOptionX{width}[]{\def\dtt@width{-w #1}}
+\DeclareOptionX{width}[]{\Gin@defaultbp\foo{#1}\def\dtt@width{-w \foo}}
 \def\dtt@width{} % default output width
-\DeclareOptionX{height}[]{\def\dtt@height{-h #1}}
+\DeclareOptionX{height}[]{\Gin@defaultbp\foo{#1}\def\dtt@height{-h \foo}}
 \def\dtt@height{} % default output height
 
 % Option for setting an output directory
@@ -91,6 +93,13 @@
 \newif\ifdtt@input \dtt@inputfalse
 \DeclareOptionX{input}{\dtt@inputtrue}
 \DeclareOptionX{noinput}{\dtt@inputfalse}
+
+\DeclareOptionX{cmdprefix}[]{\def\dtt@cmdprefix{#1 }}
+\def\dtt@cmdprefix{} % default command prefix
+
+\newif\ifdtt@beamer \dtt@beamerfalse
+\DeclareOptionX{beamer}{\dtt@beamertrue}
+\DeclareOptionX{nobeamer}{\dtt@beamerfalse}
 
 \ExecuteOptionsX{shell}
 
@@ -159,10 +168,12 @@
 
 % Options
 \define@key{dtt}{width}[]{%
-    \def\dtt@width{-w #1}
+    \Gin@defaultbp\foo{#1}
+    \def\dtt@width{-w \foo}
 }
 \define@key{dtt}{height}[]{%
-    \def\dtt@height{-h #1}
+    \Gin@defaultbp\foo{#1}
+    \def\dtt@height{-h \foo}
 }
 
 \define@key{dtt}{outputdir}[]{%
@@ -227,14 +238,18 @@
       \immediate\write18{mkdir -p \dtt@outputdir}
     \fi
     \xdef\diagramslatexCutFile{\dtt@figname.hs}
-    \diagramslatexverbatimwrite{\diagramslatexCutFile}}
-    {\enddiagramslatexverbatimwrite%
+    \diagramslatexverbatimwrite{\diagramslatexCutFile}
+    }
+    {\ifdtt@beamer\ifdefined\beamer@slideinframe
+    \immediate\write\verbatim@out{overlay = \number\beamer@slideinframe\space :: Int}
+    \fi\fi
+    \enddiagramslatexverbatimwrite%
     \diagramslatexgraphicsinclude}
 
 \long\gdef\diagramslatexgraphicsprocess{%
     \ifdtt@ShellEscape
         \IfFileExists{\dtt@figname.hs}{%
-            \immediate\write18{diagrams-builder-\dtt@backend\space -o \dtt@figname.\dtt@extension\space
+            \immediate\write18{\dtt@cmdprefix diagrams-builder-\dtt@backend\space -o \dtt@figname.\dtt@extension\space
                 \dtt@width\space
                 \dtt@height\space
                 \dtt@figname.hs\space }%


### PR DESCRIPTION
I hope this is an acceptable patch. I am not a TeX expert by any means, I just tried to evaluate diagrams as a candidate to replace TikZ in presentations and articles and these were just some of the usability issues that were nagging me enough that I tried to fix it...

I added a cmdprefix option, for example one can write

`\usepackage[backend=pgf, extension=pgf, outputdir=diagrams, input, cmdprefix={stack exec --}, beamer]{diagrams-latex}`

and then it works nicely with diagrams installed in the global project by stack.

The `beamer` option makes diagrams aware of overlays when using with beamer. It defines the `overlay` variable that can be used in the script to vary the diagram depending on the slide number. The only drawback is that this enforces the indentation level (as a line of code is added). I don't know whether there is a nice way to do this smarter, but I think this is better than nothing and if one does not enable it, the base indentation depth remains "flexible", as before.

Furthermore, I didn't like that `width` and `height` were unitless numbers. Now one can write `\begin{diagram}[width=\textwidth]` and it works as one would expect.

