### PR TITLE
Fix Postscript backend build failure

### DIFF
--- a/diagrams-builder.cabal
+++ b/diagrams-builder.cabal
@@ -49,7 +49,7 @@ library
                        Diagrams.Builder.Modules
                        Diagrams.Builder.CmdLine
   build-depends:       base >= 4.10 && < 4.18,
-                       base-orphans >= 0.3 && < 0.9,
+                       base-orphans >= 0.3 && < 0.10,
                        mtl >= 2.1 && < 2.3,
                        diagrams-lib >= 1.4 && < 1.5,
                        hint >= 0.4 && < 0.10,
@@ -118,7 +118,7 @@ executable diagrams-builder-cairo
                        diagrams-lib >= 1.4 && < 1.5,
                        diagrams-cairo >= 1.4 && < 1.5,
                        cmdargs >= 0.6 && < 0.11,
-                       lens >= 4.0 && < 5.2
+                       lens >= 4.0 && < 5.3
 
 executable diagrams-builder-svg
   main-is:             diagrams-builder-svg.hs
@@ -157,9 +157,10 @@ executable diagrams-builder-ps
                        directory,
                        diagrams-builder,
                        diagrams-lib >= 1.4 && < 1.5,
-                       diagrams-postscript >= 1.4 && < 1.5,
+                       diagrams-postscript >= 1.4 && < 1.6,
                        cmdargs >= 0.6 && < 0.11,
-                       lens >= 3.8 && < 5.2
+                       lens >= 3.8 && < 5.3,
+                       bytestring >= 0.9.2 && < 0.12
 
 executable diagrams-builder-rasterific
   main-is:             diagrams-builder-rasterific.hs
@@ -179,7 +180,7 @@ executable diagrams-builder-rasterific
                        diagrams-lib >= 1.4 && < 1.5,
                        diagrams-rasterific >= 1.4 && < 1.5,
                        cmdargs >= 0.6 && < 0.11,
-                       lens >= 3.8 && < 5.2,
+                       lens >= 3.8 && < 5.3,
                        JuicyPixels >= 3.1.5 && < 3.4
 
 executable diagrams-builder-pgf
@@ -201,5 +202,5 @@ executable diagrams-builder-pgf
                        diagrams-pgf >= 1.4 && < 1.5,
                        bytestring >= 0.10.2 && < 0.12,
                        cmdargs >= 0.6 && < 0.11,
-                       lens >= 3.8 && < 5.2,
+                       lens >= 3.8 && < 5.3,
                        texrunner


### PR DESCRIPTION
As part of an effort to bring back `diagrams-*` family of packages on nix package repository to a building state, I made a few changes so that `diagrams-builder` compiles with `ps` flag turned on. Tested with GHC 8.10.7, 9.0.2, and 9.2.7.